### PR TITLE
fix a bug that throw an error when the file has a syntax error

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,8 +85,12 @@ module.exports = function (opt) {
         if (file.isNull()) {
             this.push(file);
         } else if (file.isBuffer()) {
-            transform(file, encoding, opt);
-            this.push(file);
+            try {
+              transform(file, encoding, opt);
+              this.push(file);
+            } catch (err) {
+              return callback(new gutil.PluginError('gulp-espoewr', err, {showStack: true}));
+            }
         } else if (file.isStream()) {
             file.contents = file.contents.pipe(new BufferStreams(function(err, buf, cb) {
                 if(err) {

--- a/test/fixtures/syntax-error.js
+++ b/test/fixtures/syntax-error.js
@@ -1,0 +1,5 @@
+var assert = require('power-assert'),
+    truthy = 'true',
+    falsy = 'false';
+assert(falsy);
+assert.equal(truthy, // falsy); // SYNTAX ERROR!

--- a/test/test.js
+++ b/test/test.js
@@ -228,4 +228,21 @@ describe("gulp-espower", function () {
         stream.end();
     });
 
+    it('should emit the error when the file has a syntax error', function (done) {
+        var stream = espower(),
+            srcFile = new gutil.File({
+                path: "test/fixtures/syntax-error.js",
+                cwd: "test/",
+                base: "test/fixtures",
+                contents: fs.readFileSync("test/fixtures/syntax-error.js")
+            });
+        assert.doesNotThrow(function() {
+          stream.on("error", function(err) {
+            assert(err);
+            done();
+          });
+          stream.write(srcFile);
+          stream.end();
+        });
+    });
 });


### PR DESCRIPTION
```
[21:48:20] Using gulpfile ~/node-hatena-bookmark-api/gulpfile.js
[21:48:20] Starting 'watch'...
[21:48:20] Finished 'watch' after 7.39 ms
[21:48:28] Starting 'test'...

/home/bouzuya/node-hatena-bookmark-api/node_modules/gulp-espower/node_modules/esprima/esprima.js:3719
            throw e;
                  ^
Error: Line 91: Unexpected end of input
    at throwError (/home/bouzuya/node-hatena-bookmark-api/node_modules/gulp-espower/node_modules/esprima/esprima.js:1831:21)
    at throwUnexpected (/home/bouzuya/node-hatena-bookmark-api/node_modules/gulp-espower/node_modules/esprima/esprima.js:1863:13)
    at expect (/home/bouzuya/node-hatena-bookmark-api/node_modules/gulp-espower/node_modules/esprima/esprima.js:1898:13)
    at parseFunctionSourceElements (/home/bouzuya/node-hatena-bookmark-api/node_modules/gulp-espower/node_modules/esprima/esprima.js:3326:9)
    at parseFunctionExpression (/home/bouzuya/node-hatena-bookmark-api/node_modules/gulp-espower/node_modules/esprima/esprima.js:3462:16)
    at parsePrimaryExpression (/home/bouzuya/node-hatena-bookmark-api/node_modules/gulp-espower/node_modules/esprima/esprima.js:2179:24)
    at parseLeftHandSideExpressionAllowCall (/home/bouzuya/node-hatena-bookmark-api/node_modules/gulp-espower/node_modules/esprima/esprima.js:2278:61)
    at parsePostfixExpression (/home/bouzuya/node-hatena-bookmark-api/node_modules/gulp-espower/node_modules/esprima/esprima.js:2326:16)
    at parseUnaryExpression (/home/bouzuya/node-hatena-bookmark-api/node_modules/gulp-espower/node_modules/esprima/esprima.js:2385:20)
    at parseBinaryExpression (/home/bouzuya/node-hatena-bookmark-api/node_modules/gulp-espower/node_modules/esprima/esprima.js:2474:16)
```
